### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # faucet
 
-General Faucet for Cosmos SDK testnet. There are two versions: [Cosmos](https://github.com/ping.pub/faucet) and [Evmos](https://github.com/ping-pub/faucet/tree/evmos)
+General Faucet for Cosmos SDK testnet. There are two versions: [Cosmos](https://github.com/ping-pub/faucet) and [Evmos](https://github.com/ping-pub/faucet/tree/evmos)
 
 <img width="1052" alt="preview" src="https://user-images.githubusercontent.com/2882920/202998797-b793c52b-9ad7-47fe-a80b-a0f75eff6ba1.png">
 


### PR DESCRIPTION
I don't like typos in the URLs. It makes me uncomfortable. I just wanted to fix it.