### PR TITLE
Faucet fees and configurable recaptcha

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -42,7 +42,7 @@ export default {
             ],
             fee: {
                 amount: [{ denom: "uallo", amount: "500" }],
-                gas: "200000",
+                gasPrice: "11uallo"
             },
         },
         limit: {
@@ -59,5 +59,6 @@ export default {
     reCaptcha: {
         siteKey: process.env.RECAPTCHA_SITE_KEY,
         secretKey: process.env.RECAPTCHA_SECRET_KEY
-    }
+    },
+    reCaptchaEnabled: true
 }


### PR DESCRIPTION
* Add gasPrice as a tx configuration (base only - set as `11uallo` where base price is `10uallo`). 
This is expected to sometimes not meet the sudden increases that `feemarket`  may be generating - in those cases it would fail - but it will cover most cases.
* Add recaptcha as a configurable setup, mostly for testing.